### PR TITLE
Update nn_parallel.cpp

### DIFF
--- a/src/nn_parallel.cpp
+++ b/src/nn_parallel.cpp
@@ -49,7 +49,7 @@ struct NNWorker : public RcppParallel::Worker {
     for (std::size_t i = begin; i < end; i++) {
 
       RcppParallel::RMatrix<double>::Row row = mat.row(i);
-      std::vector<T> fv(row.size());
+      std::vector<T> fv(row.length());
       std::copy(row.begin(), row.end(), fv.begin());
       std::vector<S> result;
       std::vector<T> distances;


### PR DESCRIPTION
Compilation will lead to the error: `'class RcppParallel::RMatrix<double>::Row' has no member named 'size'`. Changed `.size()` to `.length()`