### PR TITLE
transform nn

### DIFF
--- a/R/uwot.R
+++ b/R/uwot.R
@@ -1653,7 +1653,7 @@ uwot <- function(X, n_neighbors = 15, n_components = 2, metric = "euclidean",
     res <- list(embedding = embedding)
     if (ret_model) {
       res <- append(res, list(
-        scale_info = attr_to_scale_info(X),
+        scale_info = if (!is.null(X)) { attr_to_scale_info(X) } else { NULL },
         n_neighbors = n_neighbors,
         search_k = search_k,
         local_connectivity = local_connectivity,
@@ -1684,7 +1684,11 @@ uwot <- function(X, n_neighbors = 15, n_components = 2, metric = "euclidean",
           # the input data at load time)
           # To be sure of the dimensionality, fetch the first item from the 
           # index and see how many elements are in the returned vector.
-          res$metric[[1]] <- list(ndim = length(res$nn_index$getItemsVector(0)))
+          if(!is.null(X)){
+            res$metric[[1]] <- list(ndim = length(res$nn_index$getItemsVector(0)))
+          } else{
+            res$metric[[1]] <- list()
+          }
         }
       }
       if (!is.null(pca_models)) {


### PR DESCRIPTION
Thanks for answering my issue. https://github.com/jlmelville/uwot/issues/63
Here is an application. 
First, I  build training umap with precalculated nearest neighbor input and return its model.
Then, I build the test-train nearest neighbor, and put it into `umap_transform` which avoids `annoy_search` for `X`, and use precalculated test-train nearest neighbor as input. 
This NN input can give users flexibilities to add/explore their specific kernel into `umap` and `transform_umap`, not limited to the features input.  Thanks.

This is an example:
```
devtools::install_github("jlmelville/vizier")
devtools::install_github("jlmelville/snedata")
fashion <- snedata::download_fashion_mnist()
fashion_train <- head(fashion, 60000)
fashion_test <- tail(fashion, 10000)

fashion_train.nn <- uwot:::annoy_nn(X = as.matrix(fashion_train[, 1:784]),
                                    k = 15, 
                                    metric = "cosine",
                                    ret_index = T)
# return umap map with annoy_nn input
set.seed(1337)
fashion_umap <- umap(X = NULL, nn_method = fashion_train.nn, ret_model = T)

# compute the query-reference annoy_nn
query_ref.nn <- annoy_search(X = as.matrix(fashion_test[, 1:784]), 
                             k = 15, 
                             ann = fashion_train.nn$index  )

# use the query-reference annoy_nn to transform query to reference
fashion_umap_test <- umap_transform(X = NULL,  model = fashion_umap, nn_method = query_ref.nn)


vizier::embed_plot(fashion_umap$embedding, fashion, cex = 0.5, title = "Fashion UMAP", alpha_scale = 0.075)
vizier::embed_plot(fashion_umap_test, fashion_test, cex = 0.5, title = "Fashion Test UMAP", alpha_scale = 0.075)
```



```