### PR TITLE
Added a quick check to make sure "pca" is not too large

### DIFF
--- a/R/uwot.R
+++ b/R/uwot.R
@@ -1249,6 +1249,9 @@ uwot <- function(X, n_neighbors = 15, n_components = 2, metric = "euclidean",
     if (pca < n_components) {
       stop("'pca' must be >= n_components")
     }
+    if (pca > nrow(X)) {
+      stop("'pca' must be <= ncol(X)")
+    }
   }
 
   if (fast_sgd) {

--- a/R/uwot.R
+++ b/R/uwot.R
@@ -1250,7 +1250,7 @@ uwot <- function(X, n_neighbors = 15, n_components = 2, metric = "euclidean",
       stop("'pca' must be >= n_components")
     }
     if (pca > nrow(X)) {
-      stop("'pca' must be <= ncol(X)")
+      stop("'pca' must be <= nrow(X)")
     }
   }
 


### PR DESCRIPTION
Greetings!

This PR just adds a quick check in `uwot()` to ensure that the value of `pca` is not greater than the number of rows in `X`; otherwise segfaults may ensue.

Thanks for taking the time to share and maintain this very useful package!

Cheers,
Keith