### PR TITLE
Accomodate RcppAnnoy 0.16.2 or later with Annoy 1.17 (closes #69)

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,7 @@
 # Turn on C++11 support to get access to long long (guaranteed 64-bit ints)
 CXX_STD = CXX11
 
+# Add this define with Rcpp 0.16.2 or later:  -D__RcppAnnoy_0_16_2__
+# Once that release is standard just remove the define here and its test (twice) in nn_parallel.h
 PKG_CXXFLAGS = -DSTRICT_R_HEADERS -DRCPP_NO_RTTI
 PKG_CPPFLAGS = -I../inst/include/

--- a/src/nn_parallel.h
+++ b/src/nn_parallel.h
@@ -31,6 +31,14 @@
 
 #include "uwot/matrix.h"
 
+#if defined __RcppAnnoy_0_16_2__
+#ifdef ANNOYLIB_MULTITHREADED_BUILD
+  typedef AnnoyIndexMultiThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
+#else
+  typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
+#endif
+#endif
+
 struct UwotAnnoyEuclidean {
   using Distance = Euclidean;
   using S = int32_t;
@@ -66,7 +74,11 @@ template <typename UwotAnnoyDistance> struct NNWorker {
   std::vector<typename UwotAnnoyDistance::T> dists;
 
   AnnoyIndex<typename UwotAnnoyDistance::S, typename UwotAnnoyDistance::T,
+#if defined __RcppAnnoy_0_16_2__
+             typename UwotAnnoyDistance::Distance, Kiss64Random, AnnoyIndexThreadedBuildPolicy>
+#else
              typename UwotAnnoyDistance::Distance, Kiss64Random>
+#endif
       index;
 
   NNWorker(const std::string &index_name, const std::vector<double> &mat,


### PR DESCRIPTION
See #69 for discussion.  Test 
- on my box with CRAN RcppAnnoy and without the `#define`
- on my box with GitHub RcppAnnoy and with the `#define`
- on Travis per your usual grid