### PR TITLE
Use RcppAnnoy header with 0.0.17

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Imports: Rcpp,
     methods,
     FNN,
     RSpectra,
-    RcppAnnoy (>= 0.0.11),
+    RcppAnnoy (>= 0.0.17),
     irlba

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,7 +1,5 @@
 # Turn on C++11 support to get access to long long (guaranteed 64-bit ints)
 CXX_STD = CXX11
 
-# Add this define with Rcpp 0.16.2 or later:  -D__RcppAnnoy_0_16_2__
-# Once that release is standard just remove the define here and its test (twice) in nn_parallel.h
-PKG_CXXFLAGS = -DSTRICT_R_HEADERS -DRCPP_NO_RTTI
+PKG_CXXFLAGS = -DRCPP_NO_RTTI
 PKG_CPPFLAGS = -I../inst/include/

--- a/src/nn_parallel.h
+++ b/src/nn_parallel.h
@@ -19,25 +19,11 @@
 
 #include <vector>
 
-#if defined(__MINGW32__)
-#undef Realloc
-#undef Free
-#endif
-
-#define __ERROR_PRINTER_OVERRIDE__ REprintf
-
-#include <annoylib.h>
-#include <kissrandom.h>
+#include "RcppAnnoy.h"
 
 #include "uwot/matrix.h"
 
-#if defined __RcppAnnoy_0_16_2__
-#ifdef ANNOYLIB_MULTITHREADED_BUILD
-  typedef AnnoyIndexMultiThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
-#else
-  typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
-#endif
-#endif
+typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
 
 struct UwotAnnoyEuclidean {
   using Distance = Euclidean;
@@ -74,11 +60,7 @@ template <typename UwotAnnoyDistance> struct NNWorker {
   std::vector<typename UwotAnnoyDistance::T> dists;
 
   AnnoyIndex<typename UwotAnnoyDistance::S, typename UwotAnnoyDistance::T,
-#if defined __RcppAnnoy_0_16_2__
              typename UwotAnnoyDistance::Distance, Kiss64Random, AnnoyIndexThreadedBuildPolicy>
-#else
-             typename UwotAnnoyDistance::Distance, Kiss64Random>
-#endif
       index;
 
   NNWorker(const std::string &index_name, const std::vector<double> &mat,


### PR DESCRIPTION
Relates to #69. This PR:

* Changes the minimum supported version of **RcppAnnoy** to 0.0.17.
* Takes advantage of the newly-added `RcppAnnoy.h` header file to simplify the pre-amble in `nn_parallel.h`.

Pinging @LTLA @eddelbuettel just to make sure I haven't got this totally wrong.

**Note**: this will need to be part of a new CRAN release for **uwot** before the proposed changes for **RcppAnnoy** 0.0.18 can be released, i.e. the current CRAN release of **uwot** does *not* build with eddelbuettel/rcppannoy#67