### PR TITLE
Accomodate updated (Rcpp)Annoy and the added Annoy namespace

### DIFF
--- a/src/nn_parallel.h
+++ b/src/nn_parallel.h
@@ -21,6 +21,36 @@
 
 #include "RcppAnnoy.h"
 
+#if ANNOY_VERSION >= Annoy_Version(1,17,3)
+
+typedef Annoy::AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
+
+struct UwotAnnoyEuclidean {
+  using Distance = Annoy::Euclidean;
+  using S = int32_t;
+  using T = float;
+};
+
+struct UwotAnnoyCosine {
+  using Distance = Annoy::Angular;
+  using S = int32_t;
+  using T = float;
+};
+
+struct UwotAnnoyManhattan {
+  using Distance = Annoy::Manhattan;
+  using S = int32_t;
+  using T = float;
+};
+
+struct UwotAnnoyHamming {
+  using Distance = Annoy::Hamming;
+  using S = int32_t;
+  using T = uint64_t;
+};
+
+#else
+
 typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
 
 struct UwotAnnoyEuclidean {
@@ -46,6 +76,8 @@ struct UwotAnnoyHamming {
   using S = int32_t;
   using T = uint64_t;
 };
+
+#endif  // of 'if ANNOY_VERSION >= Annoy_Version(1,17,3)'
 
 template <typename UwotAnnoyDistance> struct NNWorker {
   const std::string &index_name;


### PR DESCRIPTION
Hi James,

Annoy upstream is as you know fairly stable, so I do not chase each and every update.  I did update a few days ago though when I saw @erikbern updating to 0.17.3.  And it turns out this version brings a C++ namespace which is a little disruptive in that we didn't have one before -- but then the changes are so small that it is pretty quick (once one recovers from the usual pages of C++ compiler errors).  The simplest way, I found, was to simply properly prefix indetifiers, and that is The Right Thing (TM) to do anyway.

Now, given that I altered my exposed API headers I [figured](https://github.com/eddelbuettel/rcppannoy/issues/76) I should check.  Turns out [scDHA](https://cran.r-project.org/web/packages/scDHA/index.html) does not compile (but use your package through the R interface -- and is shielded).  Your package just needs the same `Annoy::` prefixing in one header.  

I wrapped it into one bigger `#ifdef` that allow us to coexist now (compiles with CRAN `RcppAnnoy` and the release candidate in the GH repo) and allows you to, in due course, just remove the else branch.  If you think this works you can just merge, and once your new version gets to CRAN I can update too.

Let me know if that works for you. 

Best,  Dirk