### PR TITLE
Fix partial matching warning in irlba::prcomp_irlba()

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -514,7 +514,7 @@ irlba_scores <- function(X, ncol, center = TRUE, ret_extra = FALSE, verbose = FA
     X <- X * 1
   }
   res <- irlba::prcomp_irlba(X,
-    n = ncol, retx = TRUE, center = center, scale = FALSE
+    n = ncol, retx = TRUE, center = center, scale. = FALSE
   )
   report_varex(res, verbose)
   if (ret_extra) {


### PR DESCRIPTION
Link to the source code of this function, showing the arg is named `scale.`: https://github.com/bwlewis/irlba/blob/bb71306fc3c17e4325b8e80aa627ee60c8edde01/R/prcomp.R#L74